### PR TITLE
Skipping broken maps

### DIFF
--- a/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
+++ b/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
@@ -337,6 +337,103 @@ ifcontains(%CHATCLEAN%,"%@&yourign% has joined");
     echo("/map")
 endif;
 
+// Broken maps
+
+// Paradox is only in specific cases where you enter pvp, you fall down and get stuck sometimes
+ifcontains(%CHATCLEAN%,"You are currently playing on Paradox");
+    wait(100ms)
+	log("&f[&cBW&f] This is an broken map. Will requeue.")
+	keyup(jump);
+	keyup(forward);
+	keyup(left);
+	keyup(right);
+	keyup(back);
+	stop(bwattack)
+	stop(bwdefense)
+	stop(bwdrop)
+	stop(bwfirstrush)
+	stop(bwgotogen)
+	stop(bwhit)
+	stop(bwlookmid)
+	stop(bwpurchase)
+	stop(bwpvp)
+	stop(bwrc)
+	stop(bwstucktimer)
+	stop(bwteammate)
+	stop(bwtimer)
+	stop(classicaddons)
+	stop(classichit)
+	stop(classicmovement)
+	stop(classicpvpbot)
+	wait(1000ms);
+	exec("command.txt","command")
+	stop;
+endif;
+
+// In this map, the bot is unable to enter shop, by getting stuck outside
+ifcontains(%CHATCLEAN%,"You are currently playing on Eastwood");
+    wait(100ms)
+	log("&f[&cBW&f] This is an broken map. Will requeue.")
+	keyup(jump);
+	keyup(forward);
+	keyup(left);
+	keyup(right);
+	keyup(back);
+	stop(bwattack)
+	stop(bwdefense)
+	stop(bwdrop)
+	stop(bwfirstrush)
+	stop(bwgotogen)
+	stop(bwhit)
+	stop(bwlookmid)
+	stop(bwpurchase)
+	stop(bwpvp)
+	stop(bwrc)
+	stop(bwstucktimer)
+	stop(bwteammate)
+	stop(bwtimer)
+	stop(classicaddons)
+	stop(classichit)
+	stop(classicmovement)
+	stop(classicpvpbot)
+	wait(1000ms);
+	exec("command.txt","command")
+	stop;
+endif;
+
+// In this map, the glass pane is blocking the bot from clicking on the shop
+ifcontains(%CHATCLEAN%,"You are currently playing on Jurassic");
+    wait(100ms)
+	@#bridgemap = 0;
+	log("&f[&cBW&f] This is not a bridge map. Will not activate bridging on this map.")
+	log("&f[&cBW&f] This is an broken map. Will requeue.")
+	keyup(jump);
+	keyup(forward);
+	keyup(left);
+	keyup(right);
+	keyup(back);
+	stop(bwattack)
+	stop(bwdefense)
+	stop(bwdrop)
+	stop(bwfirstrush)
+	stop(bwgotogen)
+	stop(bwhit)
+	stop(bwlookmid)
+	stop(bwpurchase)
+	stop(bwpvp)
+	stop(bwrc)
+	stop(bwstucktimer)
+	stop(bwteammate)
+	stop(bwtimer)
+	stop(classicaddons)
+	stop(classichit)
+	stop(classicmovement)
+	stop(classicpvpbot)
+	wait(1000ms);
+	exec("command.txt","command")
+	stop;
+endif;
+
 //Maps to dodge.
 
 ifcontains(%CHATCLEAN%,"You are currently playing on Dreamgrove");
@@ -370,12 +467,6 @@ ifcontains(%CHATCLEAN%,"You are currently playing on Graveship");
 endif;
 
 ifcontains(%CHATCLEAN%,"You are currently playing on Mystery");
-    wait(100ms)
-	@#bridgemap = 0;
-	log("&f[&cBW&f] This is not a bridge map. Will not activate bridging on this map.")
-endif;
-
-ifcontains(%CHATCLEAN%,"You are currently playing on Jurassic");
     wait(100ms)
 	@#bridgemap = 0;
 	log("&f[&cBW&f] This is not a bridge map. Will not activate bridging on this map.")

--- a/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
+++ b/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
@@ -370,7 +370,7 @@ ifcontains(%CHATCLEAN%,"You are currently playing on Paradox");
 	stop;
 endif;
 
-// In this map, the bot is unable to enter shop, by getting stuck outside
+// In this map, when the bot tries to go back to the generator, it gets stuck here.
 ifcontains(%CHATCLEAN%,"You are currently playing on Eastwood");
     wait(100ms)
 	log("&f[&cBW&f] This is an broken map. Will requeue.")
@@ -406,6 +406,37 @@ ifcontains(%CHATCLEAN%,"You are currently playing on Jurassic");
     wait(100ms)
 	@#bridgemap = 0;
 	log("&f[&cBW&f] This is not a bridge map. Will not activate bridging on this map.")
+	log("&f[&cBW&f] This is an broken map. Will requeue.")
+	keyup(jump);
+	keyup(forward);
+	keyup(left);
+	keyup(right);
+	keyup(back);
+	stop(bwattack)
+	stop(bwdefense)
+	stop(bwdrop)
+	stop(bwfirstrush)
+	stop(bwgotogen)
+	stop(bwhit)
+	stop(bwlookmid)
+	stop(bwpurchase)
+	stop(bwpvp)
+	stop(bwrc)
+	stop(bwstucktimer)
+	stop(bwteammate)
+	stop(bwtimer)
+	stop(classicaddons)
+	stop(classichit)
+	stop(classicmovement)
+	stop(classicpvpbot)
+	wait(1000ms);
+	exec("command.txt","command")
+	stop;
+endif;
+
+// In this map, the bot gets stuck after buying items.
+ifcontains(%CHATCLEAN%,"You are currently playing on Invasion");
+    wait(100ms)
 	log("&f[&cBW&f] This is an broken map. Will requeue.")
 	keyup(jump);
 	keyup(forward);


### PR DESCRIPTION
This skips broken maps, by making the bot requeue.

Maps: Eastwood, Jurassic, Paradox and Invasion

Eastwood: When the bot tries to go back items to the generator, it gets stuck here.
![image](https://github.com/familiar/Bedwars-Bot/assets/82937056/c90fd9a8-9b87-4be4-b5c5-3ea1be37d49e)

Jurassic: When the bot tries to buy items, it gets blocked by the glass panes.
![image](https://github.com/familiar/Bedwars-Bot/assets/82937056/409f4ba0-54f9-42d7-94ab-34f00aafa2b7)

Paradox: This is only in specific cases, while fighting a player, the bot may fall down and get stuck
![image](https://github.com/familiar/Bedwars-Bot/assets/82937056/bf656810-15f5-4791-b542-3c8be382feac)

Invasion: When the bot goes back to the generator after buying items, it gets stuck here
![image](https://github.com/familiar/Bedwars-Bot/assets/82937056/4af8f922-c1a8-44f1-95ee-d85614aa915d)


NOTE: For the map Paradox, it is according to another player.

For other people having issues on other maps, please say the map name, an screenshot of where you get stuck, and what happened before (like, did it try to buy items? did it try going back to the generator after buying items?, etc)
