### PR TITLE
Made it so that people can't make the bot requeue on private messaging + Removed bridging from Relic and Harvesting due to making the bot stuck + Skipping Nostalgia

### DIFF
--- a/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
+++ b/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
@@ -404,8 +404,6 @@ endif;
 // In this map, the glass pane is blocking the bot from clicking on the shop
 ifcontains(%CHATCLEAN%,"You are currently playing on Jurassic");
     wait(100ms)
-	@#bridgemap = 0;
-	log("&f[&cBW&f] This is not a bridge map. Will not activate bridging on this map.")
 	log("&f[&cBW&f] This is an broken map. Will requeue.")
 	keyup(jump);
 	keyup(forward);

--- a/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
+++ b/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
@@ -7,6 +7,13 @@ wait(100ms)
 echo("/togglechat")
 endif
 
+//Status offline check to ensure people can't make you requeue (disables private messages)
+
+ifcontains(%CHATCLEAN%,"From")
+wait(100ms)
+echo("/status offline")
+endif
+
 // Game triggers
 
 ifcontains(%CHATCLEAN%,"Protect your bed")

--- a/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
+++ b/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
@@ -404,6 +404,8 @@ endif;
 // In this map, the glass pane is blocking the bot from clicking on the shop
 ifcontains(%CHATCLEAN%,"You are currently playing on Jurassic");
     wait(100ms)
+	@#bridgemap = 0;
+	log("&f[&cBW&f] This is not a bridge map. Will not activate bridging on this map.")
 	log("&f[&cBW&f] This is an broken map. Will requeue.")
 	keyup(jump);
 	keyup(forward);
@@ -435,6 +437,7 @@ endif;
 // In this map, the bot gets stuck after buying items.
 ifcontains(%CHATCLEAN%,"You are currently playing on Invasion");
     wait(100ms)
+	log("&f[&cBW&f] This is not a bridge map. Will not activate bridging on this map.")
 	log("&f[&cBW&f] This is an broken map. Will requeue.")
 	keyup(jump);
 	keyup(forward);
@@ -463,37 +466,28 @@ ifcontains(%CHATCLEAN%,"You are currently playing on Invasion");
 	stop;
 endif;
 
-// In this map, the bot gets stuck trying to buy items.
+//Maps that you can bridge in, but it is disabled due to it getting the bot stuck.
+
+//In this map, the bot may not find the shop in some cases
+ifcontains(%CHATCLEAN%,"You are currently playing on Nostalgia");
+    wait(100ms)
+	@#bridgemap = 0;
+	log("&f[&cBW&f] This is a bridge map. However it is making the bot stuck. Will not activate bridging on this map.")
+endif;
+
+//On this map, after bridging, the bot gets stuck
+ifcontains(%CHATCLEAN%,"You are currently playing on Relic");
+    wait(100ms)
+	@#bridgemap = 0;
+	log("&f[&cBW&f] This is a bridge map. However it is making the bot stuck. Will not activate bridging on this map.")
+endif;
+
+//On this map, after bridging, bot gets stuck under the stairs
 ifcontains(%CHATCLEAN%,"You are currently playing on Harvesting");
     wait(100ms)
-	log("&f[&cBW&f] This is an broken map. Will requeue.")
-	keyup(jump);
-	keyup(forward);
-	keyup(left);
-	keyup(right);
-	keyup(back);
-	stop(bwattack)
-	stop(bwdefense)
-	stop(bwdrop)
-	stop(bwfirstrush)
-	stop(bwgotogen)
-	stop(bwhit)
-	stop(bwlookmid)
-	stop(bwpurchase)
-	stop(bwpvp)
-	stop(bwrc)
-	stop(bwstucktimer)
-	stop(bwteammate)
-	stop(bwtimer)
-	stop(classicaddons)
-	stop(classichit)
-	stop(classicmovement)
-	stop(classicpvpbot)
-	wait(1000ms);
-	exec("command.txt","command")
-	stop;
+	@#bridgemap = 0;
+	log("&f[&cBW&f] This is a bridge map. However it is making the bot stuck. Will not activate bridging on this map.")
 endif;
-
 
 //Maps to dodge.
 
@@ -503,11 +497,6 @@ ifcontains(%CHATCLEAN%,"You are currently playing on Dreamgrove");
 	log("&f[&cBW&f] This is not a bridge map. Will not activate bridging on this map.")
 endif;
 
-ifcontains(%CHATCLEAN%,"You are currently playing on Nostalgia");
-    wait(100ms)
-	@#bridgemap = 0;
-	log("&f[&cBW&f] This is not a bridge map. Will not activate bridging on this map.")
-endif;
 
 ifcontains(%CHATCLEAN%,"You are currently playing on Lost Temple");
     wait(100ms)

--- a/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
+++ b/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
@@ -437,7 +437,6 @@ endif;
 // In this map, the bot gets stuck after buying items.
 ifcontains(%CHATCLEAN%,"You are currently playing on Invasion");
     wait(100ms)
-	log("&f[&cBW&f] This is not a bridge map. Will not activate bridging on this map.")
 	log("&f[&cBW&f] This is an broken map. Will requeue.")
 	keyup(jump);
 	keyup(forward);

--- a/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
+++ b/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
@@ -470,6 +470,37 @@ ifcontains(%CHATCLEAN%,"You are currently playing on Invasion");
 	stop;
 endif;
 
+//On this map, the bot may get stuck when buying items
+ifcontains(%CHATCLEAN%,"You are currently playing on Harvesting");
+    wait(100ms)
+	log("&f[&cBW&f] This is an broken map. Will requeue.")
+	keyup(jump);
+	keyup(forward);
+	keyup(left);
+	keyup(right);
+	keyup(back);
+	stop(bwattack)
+	stop(bwdefense)
+	stop(bwdrop)
+	stop(bwfirstrush)
+	stop(bwgotogen)
+	stop(bwhit)
+	stop(bwlookmid)
+	stop(bwpurchase)
+	stop(bwpvp)
+	stop(bwrc)
+	stop(bwstucktimer)
+	stop(bwteammate)
+	stop(bwtimer)
+	stop(classicaddons)
+	stop(classichit)
+	stop(classicmovement)
+	stop(classicpvpbot)
+	wait(1000ms);
+	exec("command.txt","command")
+	stop;
+endif;
+
 //In this map, the bot may not find the shop in some cases
 ifcontains(%CHATCLEAN%,"You are currently playing on Nostalgia");
     wait(100ms)
@@ -506,13 +537,6 @@ endif;
 
 //On this map, after bridging, the bot gets stuck
 ifcontains(%CHATCLEAN%,"You are currently playing on Relic");
-    wait(100ms)
-	@#bridgemap = 0;
-	log("&f[&cBW&f] This is a bridge map. However it is making the bot stuck. Will not activate bridging on this map.")
-endif;
-
-//On this map, after bridging, bot gets stuck under the stairs
-ifcontains(%CHATCLEAN%,"You are currently playing on Harvesting");
     wait(100ms)
 	@#bridgemap = 0;
 	log("&f[&cBW&f] This is a bridge map. However it is making the bot stuck. Will not activate bridging on this map.")

--- a/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
+++ b/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
@@ -470,14 +470,39 @@ ifcontains(%CHATCLEAN%,"You are currently playing on Invasion");
 	stop;
 endif;
 
-//Maps that you can bridge in, but it is disabled due to it getting the bot stuck.
-
 //In this map, the bot may not find the shop in some cases
 ifcontains(%CHATCLEAN%,"You are currently playing on Nostalgia");
     wait(100ms)
-	@#bridgemap = 0;
-	log("&f[&cBW&f] This is a bridge map. However it is making the bot stuck. Will not activate bridging on this map.")
+	log("&f[&cBW&f] This is an broken map. Will requeue.")
+	keyup(jump);
+	keyup(forward);
+	keyup(left);
+	keyup(right);
+	keyup(back);
+	stop(bwattack)
+	stop(bwdefense)
+	stop(bwdrop)
+	stop(bwfirstrush)
+	stop(bwgotogen)
+	stop(bwhit)
+	stop(bwlookmid)
+	stop(bwpurchase)
+	stop(bwpvp)
+	stop(bwrc)
+	stop(bwstucktimer)
+	stop(bwteammate)
+	stop(bwtimer)
+	stop(classicaddons)
+	stop(classichit)
+	stop(classicmovement)
+	stop(classicpvpbot)
+	wait(1000ms);
+	exec("command.txt","command")
+	stop;
 endif;
+
+//Maps that you can bridge in, but it is disabled due to it getting the bot stuck.
+
 
 //On this map, after bridging, the bot gets stuck
 ifcontains(%CHATCLEAN%,"You are currently playing on Relic");


### PR DESCRIPTION
Made it so that people can't make the bot requeue on private messaging by doing `/status offline` to disable them.
![image](https://github.com/familiar/Bedwars-Bot/assets/82937056/135a20cc-fa7c-46fd-af58-d6ada105a8f4)

Removed bridging from Nostalgia, Relic and Harvesting due to making the bot stuck

Nostalgia:
https://cdn.discordapp.com/attachments/1207172484739375106/1209412817288171540/2024-02-20_01-11-33.mp4?ex=65e6d475&is=65d45f75&hm=c721a1e2cea4b001dea4c5251732c60ad6fab4f82addf14d3e9722e93e39ec2f&
In this map, the bot may not find the shop in some cases

Relic: 
![image](https://github.com/familiar/Bedwars-Bot/assets/82937056/92798ae0-a395-4926-bbb2-18a2af73b3d9)
(if you wanna see it: `/replay 1e3b19e8-e2be-4606-abfd-6af6e227255e #2673e90e`)
On this map, after bridging, the bot gets stuck

For Harvesting, it used to be skipped, but now is removing bridging, as this is the issue:
![image](https://github.com/familiar/Bedwars-Bot/assets/82937056/b79ede16-ade7-480f-8f50-1c8e425f99f3)
On this map, after bridging, bot gets stuck under the stairs


