### PR TITLE
Fix typo in the check if you got kicked from Bed Wars + Stop people from requeuing using guild chat

### DIFF
--- a/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
+++ b/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
@@ -312,6 +312,12 @@ ifcontains(%CHATCLEAN%,"A disconnect occurred in your connection");
   	exec("bwstart.txt","bwstart")
 endif;
 
+ifcontains(%CHATCLEAN%,"Couldn't connect you to that server");
+    stop(all)
+	wait(1000ms)
+  	exec("bwstart.txt","bwstart")
+endif;
+
 //Initial Map Dodge
 
 ifcontains(%CHATCLEAN%,"%@&yourign% has joined");
@@ -575,11 +581,6 @@ endif;
 
 //Maps to dodge.
 
-ifcontains(%CHATCLEAN%,"You are currently playing on Dreamgrove");
-    wait(100ms)
-	@#bridgemap = 0;
-	log("&f[&cBW&f] This is not a bridge map. Will not activate bridging on this map.")
-endif;
 
 
 ifcontains(%CHATCLEAN%,"You are currently playing on Lost Temple");

--- a/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
+++ b/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
@@ -352,37 +352,6 @@ endif;
 
 // Broken maps
 
-// In this map, the bot is going 1 block too far from the generator sometimes.
-ifcontains(%CHATCLEAN%,"You are currently playing on Dreamgrove");
-    wait(100ms)
-	log("&f[&cBW&f] This is an broken map. Will requeue.")
-	keyup(jump);
-	keyup(forward);
-	keyup(left);
-	keyup(right);
-	keyup(back);
-	stop(bwattack)
-	stop(bwdefense)
-	stop(bwdrop)
-	stop(bwfirstrush)
-	stop(bwgotogen)
-	stop(bwhit)
-	stop(bwlookmid)
-	stop(bwpurchase)
-	stop(bwpvp)
-	stop(bwrc)
-	stop(bwstucktimer)
-	stop(bwteammate)
-	stop(bwtimer)
-	stop(classicaddons)
-	stop(classichit)
-	stop(classicmovement)
-	stop(classicpvpbot)
-	wait(1000ms);
-	exec("command.txt","command")
-	stop;
-endif;
-
 // Paradox is only in specific cases where you enter pvp, you fall down and get stuck sometimes
 ifcontains(%CHATCLEAN%,"You are currently playing on Paradox");
     wait(100ms)

--- a/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
+++ b/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
@@ -306,7 +306,7 @@ ifcontains(%CHATCLEAN%,"You were spawned in Limbo.");
   exec("bwstart.txt","bwstart")
 endif;
 
-ifcontains(%CHATCLEAN%,"A disconnect occured in your connection");
+ifcontains(%CHATCLEAN%,"A disconnect occurred in your connection");
     stop(all)
 	wait(1000ms)
   	exec("bwstart.txt","bwstart")

--- a/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
+++ b/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
@@ -346,6 +346,37 @@ endif;
 
 // Broken maps
 
+// In this map, the bot is going 1 block too far from the generator sometimes.
+ifcontains(%CHATCLEAN%,"You are currently playing on Dreamgrove");
+    wait(100ms)
+	log("&f[&cBW&f] This is an broken map. Will requeue.")
+	keyup(jump);
+	keyup(forward);
+	keyup(left);
+	keyup(right);
+	keyup(back);
+	stop(bwattack)
+	stop(bwdefense)
+	stop(bwdrop)
+	stop(bwfirstrush)
+	stop(bwgotogen)
+	stop(bwhit)
+	stop(bwlookmid)
+	stop(bwpurchase)
+	stop(bwpvp)
+	stop(bwrc)
+	stop(bwstucktimer)
+	stop(bwteammate)
+	stop(bwtimer)
+	stop(classicaddons)
+	stop(classichit)
+	stop(classicmovement)
+	stop(classicpvpbot)
+	wait(1000ms);
+	exec("command.txt","command")
+	stop;
+endif;
+
 // Paradox is only in specific cases where you enter pvp, you fall down and get stuck sometimes
 ifcontains(%CHATCLEAN%,"You are currently playing on Paradox");
     wait(100ms)

--- a/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
+++ b/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
@@ -14,6 +14,13 @@ wait(100ms)
 echo("/status offline")
 endif
 
+//Guild Toggle check to ensure people can't you requeue (disables guild chat for you), this is for the people that uses main accounts while being in a guild...
+
+ifcontains(%CHATCLEAN%,"From")
+wait(100ms)
+echo("/guild toggle")
+endif
+
 // Game triggers
 
 ifcontains(%CHATCLEAN%,"Protect your bed")


### PR DESCRIPTION
The message in the check if you got kicked was missing an `r`... fixed it

Skipped dreamgrove:
![image](https://github.com/familiar/Bedwars-Bot/assets/82937056/56ae14d7-8b8b-4976-8bc6-2e149f8a6364)
In some cases, the bot would go too far, which makes it sometimes unable to collect resources (in this case in the message, it managed to do it, but sometimes it doesn't)