### PR TITLE
Take a screenshot only if you win

### DIFF
--- a/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
+++ b/BedwarsAFKv2/liteconfig/common/macros/onChat.txt
@@ -181,11 +181,16 @@ ifcontains(%CHATCLEAN%,"Your bed was destroyed so you are a spectator!")
 	exec("Command.txt","Command")
 endif
 
+//With Hypixel's new system, you gain tokens whenever you win a minigame. Admins have confirmed this won't be changing anytime soon.
+
+ifcontains(%CHATCLEAN%,"tokens! (Win)")
+	wait(200ms)	
+	exec("screenshot.txt","screenshot")
+endif
+
 ifcontains(%CHATCLEAN%,"Reward Summary")
 	echo("gg")
-	wait(100ms)
-	exec("screenshot.txt","screenshot")
-	wait(100ms)
+	wait(300ms)
 	log("&f[&cBW&f] Game Ended. Requeueing.")
     stop(bwafk)
 	stop(bwattack)


### PR DESCRIPTION
With Hypixel's new "tokens" system, you gain tokens whenever you get a kill, a final kill, a bed break, or other game event.

Since you are guaranteed to get this "tokens" message if you win the game, this can be used to trigger the screenshot function, instead of listening for "Rewards Summary", which simply indicates that the game has ended.

Proof:

Bedwars win: https://imgur.com/WJjEjQl

Classic Duels win: https://imgur.com/lPyjlz3